### PR TITLE
Add check for Elasticsearch monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ https://exchange.nagios.org/directory/Plugins/Operating-Systems/*-Virtual-Enviro
 
 
 #####   CHANGELIST  #####
+##  1.0.2
+    -   Added support for Elasticsearch metrics (to be used with  the --elasticsearch-metric option)
+        for instance, call it with "-f /path/to/credentials -i ClientId:DomainName -a eu-west-1 -X CPUUtilization -w 1000:79 -S Average,Minimum,Maximum"
 
 ##  1.0.1
     -   Added support for Elasticache metric (to be used with  the --elasticache-metric option)

--- a/check_cloudwatch_status.rb
+++ b/check_cloudwatch_status.rb
@@ -359,7 +359,7 @@ begin
     aws_api = Fog::AWS::ELB.new(:aws_access_key_id => access_key_id, :aws_secret_access_key => secret_access_key, :region => region)
   elsif namespace.eql?(AWS_NAMESPACE_ELASTICACHE)
     aws_api = Fog::AWS::Elasticache.new(:aws_access_key_id => access_key_id, :aws_secret_access_key => secret_access_key, :region => region)
-  elsif namespace.eql?(AWS_NAMESPACE_ELASTICACHE)
+  elsif namespace.eql?(AWS_NAMESPACE_ES)
     aws_api = Fog::AWS::CloudWatch.new(:aws_access_key_id => access_key_id, :aws_secret_access_key => secret_access_key, :region => region)
   end
 rescue Exception => e


### PR DESCRIPTION
For the Elasticsearch, the instance id needs to be provided as a colon(:) seperated list for ClientId and DomainName.
